### PR TITLE
fixing issue when wifi connects but no connection was requested

### DIFF
--- a/Platformio/HAL/Targets/ESP32/wifiHandler/wifihandler.cpp
+++ b/Platformio/HAL/Targets/ESP32/wifiHandler/wifihandler.cpp
@@ -179,7 +179,7 @@ void wifiHandler::begin()
         //strcpy(this->password, password.c_str());
         this->SSID = ssid.c_str();
         this->password = password.c_str();
-        //this->connect(std::make_shared<std::string>(std::string(this->SSID)), std::make_shared<std::string>(std::string(this->password)));
+        this->connect(std::make_shared<std::string>(std::string(this->SSID)), std::make_shared<std::string>(std::string(this->password)));
     }
     else
     {

--- a/Platformio/HAL/Targets/ESP32/wifiHandler/wifihandler.cpp
+++ b/Platformio/HAL/Targets/ESP32/wifiHandler/wifihandler.cpp
@@ -109,6 +109,8 @@ void wifiHandler::update_status()
 
 void wifiHandler::update_credentials()
 {
+  // No connection was attempted so don't try to to save the creds
+  if(!this->connect_attempt) return;
 #if 0
     if (strcmp(temporary_password, wifiHandler::password) != 0 || strcmp(temporary_ssid, wifiHandler::SSID) != 0)
     {
@@ -138,6 +140,7 @@ void wifiHandler::update_credentials()
     preferences.end();
   }
 #endif
+this->connect_attempt = false;
 }
 
 void wifiHandler::scan()
@@ -200,6 +203,7 @@ void wifiHandler::onStatusUpdate(std::function<void (std::shared_ptr<wifiStatus>
 
 void wifiHandler::connect(std::shared_ptr<std::string> ssid, std::shared_ptr<std::string> password)
 {
+  this->connect_attempt = true;
   this->temporary_password = password;
   this->temporary_ssid = ssid;
   WiFi.begin(ssid->c_str(), password->c_str());

--- a/Platformio/HAL/Targets/ESP32/wifiHandler/wifihandler.hpp
+++ b/Platformio/HAL/Targets/ESP32/wifiHandler/wifihandler.hpp
@@ -66,6 +66,7 @@ class wifiHandler: public wifiHandlerInterface {
         std::string getIP();
         wifiStatus wifi_status;
         static std::shared_ptr<wifiHandler> mInstance;
+        bool connect_attempt = false;
         std::shared_ptr<std::string> temporary_password;
         std::shared_ptr<std::string> temporary_ssid;
 


### PR DESCRIPTION
When a scan was initiated the esp chip had an old ssid to connect to so it tried to save the ssid/password when connect was never called.